### PR TITLE
Cache rendered chunks with ChunkCacheService

### DIFF
--- a/src/Controllers/AssociationController.php
+++ b/src/Controllers/AssociationController.php
@@ -64,26 +64,25 @@ class AssociationController extends Controller
         $user = $this->auth->getUser();
 
         $language = $this->languageService->getCurrentLanguageFor($user);
+        $result = $this->getServerCachedChunk(
+            sprintf('chunks:latest:associations:%d', $language->getId()),
+            function () use ($language) {
+                $associations = $this
+                    ->associationRepository
+                    ->getLastAddedByLanguage(
+                        $language,
+                        $this->associationConfig->associationLastAddedLimit()
+                    );
 
-        $associations = $this
-            ->associationRepository
-            ->getLastAddedByLanguage(
-                $language,
-                $this->associationConfig->associationLastAddedLimit()
-            );
+                return $associations->any()
+                    ? $this->renderer->component(
+                        'association_list',
+                        ['associations' => $associations]
+                    )
+                    : $this->translate('No associations yet. :(');
+            }
+        );
 
-        return $associations->any()
-            ? $this->render(
-                $response,
-                'components/association_list.twig',
-                $this->buildParams(
-                    [
-                        'params' => [
-                            'associations' => $associations,
-                        ],
-                    ]
-                )
-            )
-            : Response::text($response, $this->translate('No associations yet. :('));
+        return Response::text($response, $result);
     }
 }

--- a/src/Controllers/Controller.php
+++ b/src/Controllers/Controller.php
@@ -14,6 +14,7 @@ use App\Semantics\PartOfSpeech;
 use App\Semantics\Scope;
 use App\Semantics\Severity;
 use App\Services\CasesService;
+use App\Services\ChunkCacheService;
 use App\Services\LanguageService;
 use Plasticode\Controllers\Controller as BaseController;
 use Plasticode\Core\AppContext;
@@ -30,6 +31,7 @@ class Controller extends BaseController
     protected WordRepositoryInterface $wordRepository;
 
     protected CasesService $casesService;
+    protected ChunkCacheService $chunkCacheService;
     protected LanguageService $languageService;
 
     protected AssociationConfigInterface $associationConfig;
@@ -54,6 +56,7 @@ class Controller extends BaseController
             $container->get(WordRepositoryInterface::class);
 
         $this->casesService = $container->get(CasesService::class);
+        $this->chunkCacheService = $container->get(ChunkCacheService::class);
         $this->languageService = $container->get(LanguageService::class);
 
         $this->associationConfig = $container->get(AssociationConfigInterface::class);
@@ -142,5 +145,24 @@ class Controller extends BaseController
     )
     {
         return $request->getQueryParams()[$param] ?? $default;
+    }
+
+    protected function getServerCachedChunk(
+        string $cacheKey,
+        callable $producer
+    ): string
+    {
+        return $this->chunkCacheService->remember(
+            $cacheKey,
+            function () use ($producer) {
+                $produced = $producer();
+
+                if ($produced instanceof ResponseInterface) {
+                    return strval($produced->getBody());
+                }
+
+                return strval($produced);
+            }
+        );
     }
 }

--- a/src/Controllers/LanguageController.php
+++ b/src/Controllers/LanguageController.php
@@ -27,40 +27,44 @@ class LanguageController extends Controller
         $user = $this->auth->getUser();
 
         $language = $this->languageService->getCurrentLanguageFor($user);
+        $result = $this->getServerCachedChunk(
+            sprintf('chunks:stats:language:%d', $language->getId()),
+            function () use ($language) {
+                $wordCount = $this
+                    ->wordRepository
+                    ->getCountByLanguage($language);
 
-        $wordCount = $this
-            ->wordRepository
-            ->getCountByLanguage($language);
+                $wordCountStr = $this
+                    ->casesService
+                    ->wordCount($wordCount);
 
-        $wordCountStr = $this
-            ->casesService
-            ->wordCount($wordCount);
+                $associationCount = $this
+                    ->associationRepository
+                    ->getCountByLanguage($language);
 
-        $associationCount = $this
-            ->associationRepository
-            ->getCountByLanguage($language);
+                $associationCountStr = $this
+                    ->casesService
+                    ->associationCount($associationCount);
 
-        $associationCountStr = $this
-            ->casesService
-            ->associationCount($associationCount);
+                return $this->renderer->component(
+                    'language_stats',
+                    [
+                        'word_count' => $wordCount,
+                        'word_count_str' => $wordCountStr,
 
-        $result = $this->renderer->component(
-            'language_stats',
-            [
-                'word_count' => $wordCount,
-                'word_count_str' => $wordCountStr,
+                        'word_anniversary' => $this
+                            ->anniversaryService
+                            ->toAnniversary($wordCount),
 
-                'word_anniversary' => $this
-                    ->anniversaryService
-                    ->toAnniversary($wordCount),
+                        'association_count' => $associationCount,
+                        'association_count_str' => $associationCountStr,
 
-                'association_count' => $associationCount,
-                'association_count_str' => $associationCountStr,
-
-                'association_anniversary' => $this
-                    ->anniversaryService
-                    ->toAnniversary($associationCount),
-            ]
+                        'association_anniversary' => $this
+                            ->anniversaryService
+                            ->toAnniversary($associationCount),
+                    ]
+                );
+            }
         );
 
         return Response::text($response, $result);

--- a/src/Controllers/WordController.php
+++ b/src/Controllers/WordController.php
@@ -133,22 +133,25 @@ class WordController extends Controller
         $user = $this->auth->getUser();
 
         $language = $this->languageService->getCurrentLanguageFor($user);
+        $result = $this->getServerCachedChunk(
+            sprintf('chunks:latest:words:%d', $language->getId()),
+            function () use ($language) {
+                $words = $this
+                    ->wordRepository
+                    ->getLastAddedByLanguage(
+                        $language,
+                        $this->wordConfig->wordLastAddedLimit()
+                    );
 
-        $words = $this
-            ->wordRepository
-            ->getLastAddedByLanguage(
-                $language,
-                $this->wordConfig->wordLastAddedLimit()
-            );
+                return $words->any()
+                    ? $this->renderer->component(
+                        'word_list',
+                        ['words' => $words]
+                    )
+                    : $this->translate('No words yet. :(');
+            }
+        );
 
-        return $words->any()
-            ? $this->render(
-                $response,
-                'components/word_list.twig',
-                $this->buildParams([
-                    'params' => ['words' => $words],
-                ])
-            )
-            : Response::text($response, $this->translate('No words yet. :('));
+        return Response::text($response, $result);
     }
 }

--- a/src/Services/ChunkCacheService.php
+++ b/src/Services/ChunkCacheService.php
@@ -9,10 +9,11 @@ class ChunkCacheService
 
     private string $cacheDir;
 
-    public function __construct(?string $cacheDir = null)
+    public function __construct()
     {
-        $this->cacheDir = $cacheDir
-            ?? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'associations_chunk_cache';
+        $this->cacheDir = sys_get_temp_dir()
+            . DIRECTORY_SEPARATOR
+            . 'associations_chunk_cache';
     }
 
     public function remember(string $key, callable $producer): string

--- a/src/Services/ChunkCacheService.php
+++ b/src/Services/ChunkCacheService.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Services;
+
+class ChunkCacheService
+{
+    private const BASE_TTL_SECONDS = 24 * 60 * 60;
+    private const TTL_JITTER_SECONDS = 4 * 60 * 60;
+
+    private string $cacheDir;
+
+    public function __construct(?string $cacheDir = null)
+    {
+        $this->cacheDir = $cacheDir
+            ?? sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'associations_chunk_cache';
+    }
+
+    public function remember(string $key, callable $producer): string
+    {
+        $cached = $this->get($key);
+
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $content = $producer();
+        $this->put($key, $content);
+
+        return $content;
+    }
+
+    private function get(string $key): ?string
+    {
+        $path = $this->pathByKey($key);
+
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $raw = file_get_contents($path);
+
+        if ($raw === false) {
+            return null;
+        }
+
+        $data = json_decode($raw, true);
+
+        if (
+            !is_array($data)
+            || !isset($data['expires_at'])
+            || !isset($data['content'])
+            || $data['expires_at'] <= time()
+        ) {
+            @unlink($path);
+            return null;
+        }
+
+        return strval($data['content']);
+    }
+
+    private function put(string $key, string $content): void
+    {
+        $this->ensureCacheDir();
+
+        $payload = json_encode(
+            [
+                'expires_at' => time() + $this->ttlWithJitter(),
+                'content' => $content,
+            ],
+            JSON_UNESCAPED_UNICODE
+        );
+
+        if ($payload === false) {
+            return;
+        }
+
+        @file_put_contents($this->pathByKey($key), $payload, LOCK_EX);
+    }
+
+    private function ttlWithJitter(): int
+    {
+        return self::BASE_TTL_SECONDS
+            + random_int(-self::TTL_JITTER_SECONDS, self::TTL_JITTER_SECONDS);
+    }
+
+    private function ensureCacheDir(): void
+    {
+        if (!is_dir($this->cacheDir)) {
+            @mkdir($this->cacheDir, 0777, true);
+        }
+    }
+
+    private function pathByKey(string $key): string
+    {
+        return $this->cacheDir
+            . DIRECTORY_SEPARATOR
+            . sha1($key)
+            . '.json';
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce repeated database queries and template rendering for small page fragments by caching rendered chunks on the server side.

### Description

- Introduces `ChunkCacheService` which provides a simple file-based cache with a TTL and jitter (`BASE_TTL_SECONDS` and `TTL_JITTER_SECONDS`).
- Wires `ChunkCacheService` into the base `Controller` and adds `getServerCachedChunk(string $cacheKey, callable $producer): string` to centralize chunk caching and stringification of produced content.
- Updates `WordController::latestChunk`, `AssociationController::latestChunk`, and `LanguageController::statsChunk` to use `getServerCachedChunk` and return the cached rendered content, replacing the previous inline rendering logic.
- Cache keys include the language id (for example `chunks:latest:words:%d` and `chunks:stats:language:%d`) to scope cached chunks per language.

### Testing

- No new automated tests were added for the cache; the change is covered by existing behavior-preserving updates. 
- Ran the project test suite with `vendor/bin/phpunit` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88e3ca5ec832eab7b17c24381950a)