### PR TITLE
Add Google authentication for site and API clients

### DIFF
--- a/db/migrations/20260410110000_add_google_id_to_users.php
+++ b/db/migrations/20260410110000_add_google_id_to_users.php
@@ -1,0 +1,16 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddGoogleIdToUsers extends AbstractMigration
+{
+    public function change()
+    {
+        $table = $this->table('users');
+
+        $table
+            ->addColumn('google_id', 'string', ['limit' => 64, 'null' => true, 'after' => 'email'])
+            ->addIndex(['google_id'], ['unique' => true])
+            ->update();
+    }
+}

--- a/settings/entities.yml
+++ b/settings/entities.yml
@@ -412,11 +412,15 @@ users:
       name: Тип
       attributes: [readonly, no_sort]
       template: >
-        (row.is_telegram ? 'Telegram' : '') + (row.is_alice ? 'Alice' : '') + (row.is_sber ? 'Sber' : '')
+        (row.is_telegram ? 'Telegram' : '') + (row.is_alice ? 'Alice' : '') + (row.is_sber ? 'Sber' : '') + (row.is_google ? 'Google' : '')
 
     email:
       name: E-mail
       type: email
+      attributes: [hidden, nullable]
+
+    google_id:
+      name: Google ID
       attributes: [hidden, nullable]
 
     gender:

--- a/settings/general.yml
+++ b/settings/general.yml
@@ -24,6 +24,10 @@ captcha_digits: 2
 # in hours
 token_ttl: 168
 
+
+google_auth:
+  client_ids: {GOOGLE_AUTH_CLIENT_IDS}
+
 # folders for PHP code
 folders:
   root: {ROOT_PATH}

--- a/settings/view_globals.yml
+++ b/settings/view_globals.yml
@@ -25,12 +25,13 @@ folders:
 mde: true
 
 disqus_alias: associ
-google_analytics_id: {GOOGLE_ANALYTICS_ID}
-google_auth_client_id: {GOOGLE_AUTH_WEB_CLIENT_ID}
 telegram_bot_name: AssociRuBot
 twitter_alias: AssociRu
 alice_url: https://dialogs.yandex.ru/store/skills/36d6b4ed-associacii
 sber_url: https://apps.sber.ru/salute-apps/f04d7fe5-000f-4980-aa0b-dc904f639ed4/
+
+google_analytics_id: {GOOGLE_ANALYTICS_ID}
+google_auth_client_id: {GOOGLE_AUTH_WEB_CLIENT_ID}
 
 angular:
   app: bsApp

--- a/settings/view_globals.yml
+++ b/settings/view_globals.yml
@@ -26,6 +26,7 @@ mde: true
 
 disqus_alias: associ
 google_analytics_id: {GOOGLE_ANALYTICS_ID}
+google_auth_client_id: {GOOGLE_AUTH_WEB_CLIENT_ID}
 telegram_bot_name: AssociRuBot
 twitter_alias: AssociRu
 alice_url: https://dialogs.yandex.ru/store/skills/36d6b4ed-associacii

--- a/src/Controllers/GoogleAuthController.php
+++ b/src/Controllers/GoogleAuthController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Services\GoogleAuthService;
+use Exception;
+use Plasticode\Core\Response;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class GoogleAuthController extends Controller
+{
+    private GoogleAuthService $googleAuthService;
+
+    public function __construct(ContainerInterface $container)
+    {
+        parent::__construct($container);
+
+        $this->googleAuthService = $container->get(GoogleAuthService::class);
+    }
+
+    public function signIn(
+        ServerRequestInterface $request,
+        ResponseInterface $response
+    ): ResponseInterface {
+        try {
+            $idToken = $this->extractIdToken($request);
+
+            $signIn = $this->googleAuthService->signIn($idToken);
+
+            $token = $signIn['token'];
+            $user = $signIn['user'];
+            $cookieKey = $signIn['cookie_key'];
+            $expiresAt = $signIn['expires_at'];
+
+            $cookie = sprintf(
+                '%s=%s; Path=/; HttpOnly; SameSite=Lax; Expires=%s',
+                rawurlencode($cookieKey),
+                rawurlencode($token),
+                gmdate('D, d M Y H:i:s T', strtotime($expiresAt))
+            );
+
+            $response = $response->withAddedHeader('Set-Cookie', $cookie);
+
+            return Response::json(
+                $response,
+                [
+                    'ok' => true,
+                    'token' => $token,
+                    'expires_at' => $expiresAt,
+                    'user' => $user->serialize(),
+                ]
+            );
+        } catch (Exception $ex) {
+            return Response::json(
+                $response->withStatus(400),
+                [
+                    'ok' => false,
+                    'message' => $ex->getMessage(),
+                ]
+            );
+        }
+    }
+
+    private function extractIdToken(ServerRequestInterface $request): string
+    {
+        $body = $request->getParsedBody();
+
+        if (!is_array($body)) {
+            return '';
+        }
+
+        return trim(strval($body['id_token'] ?? $body['credential'] ?? ''));
+    }
+}

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -11,6 +11,7 @@ use Plasticode\Util\Date;
 
 /**
  * @property integer $age
+ * @property string|null $googleId
  * @method AliceUser|null aliceUser()
  * @method Game|null currentGame()
  * @method bool isMature()
@@ -98,7 +99,7 @@ class User extends UserBase implements GenderedInterface, UserInterface
 
     public function isGoogleUser(): bool
     {
-        return strlen(strval($this->googleId ?? '')) > 0;
+        return strlen($this->googleId) > 0;
     }
 
     public function isGroup(): bool

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -96,6 +96,11 @@ class User extends UserBase implements GenderedInterface, UserInterface
         return $this->sberUser() !== null;
     }
 
+    public function isGoogleUser(): bool
+    {
+        return strlen(strval($this->googleId ?? '')) > 0;
+    }
+
     public function isGroup(): bool
     {
         $tgUser = $this->telegramUser();
@@ -147,6 +152,7 @@ class User extends UserBase implements GenderedInterface, UserInterface
             'is_telegram' => $this->isTelegramUser(),
             'is_alice' => $this->isAliceUser(),
             'is_sber' => $this->isSberUser(),
+            'is_google' => $this->isGoogleUser(),
         ];
     }
 

--- a/src/Services/GoogleAuthService.php
+++ b/src/Services/GoogleAuthService.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use App\Repositories\Interfaces\UserRepositoryInterface;
+use DateInterval;
+use DateTimeImmutable;
+use Exception;
+use GuzzleHttp\Client;
+use Plasticode\Settings\Interfaces\SettingsProviderInterface;
+
+class GoogleAuthService
+{
+    private const TOKEN_LENGTH = 16;
+    private const DEFAULT_COOKIE_KEY = 'auth_token';
+
+    private Client $httpClient;
+    private SettingsProviderInterface $settingsProvider;
+    private UserRepositoryInterface $userRepository;
+
+    public function __construct(
+        Client $httpClient,
+        SettingsProviderInterface $settingsProvider,
+        UserRepositoryInterface $userRepository
+    ) {
+        $this->httpClient = $httpClient;
+        $this->settingsProvider = $settingsProvider;
+        $this->userRepository = $userRepository;
+    }
+
+    /**
+     * @return array{token:string,user:User,expires_at:string,cookie_key:string}
+     */
+    public function signIn(string $idToken): array
+    {
+        $payload = $this->verifyIdToken($idToken);
+
+        $user = $this->resolveUser($payload);
+
+        $token = bin2hex(random_bytes(self::TOKEN_LENGTH));
+
+        $expiresAt = $this->buildExpiresAt();
+
+        \ORM::for_table('auth_tokens')
+            ->create([
+                'user_id' => $user->getId(),
+                'token' => $token,
+                'expires_at' => $expiresAt,
+            ])
+            ->save();
+
+        $cookieKey = $this->settingsProvider->get('auth_token_key')
+            ?: self::DEFAULT_COOKIE_KEY;
+
+        return [
+            'token' => $token,
+            'user' => $user,
+            'expires_at' => $expiresAt,
+            'cookie_key' => $cookieKey,
+        ];
+    }
+
+    private function buildExpiresAt(): string
+    {
+        $ttlHours = intval($this->settingsProvider->get('token_ttl') ?? 168);
+
+        $expiresAt = (new DateTimeImmutable())
+            ->add(new DateInterval('PT' . $ttlHours . 'H'));
+
+        return $expiresAt->format('Y-m-d H:i:s');
+    }
+
+    private function resolveUser(array $payload): User
+    {
+        $googleId = strval($payload['sub'] ?? '');
+
+        if (strlen($googleId) === 0) {
+            throw new Exception('Google user id is missing.');
+        }
+
+        $row = \ORM::for_table('users')
+            ->where('google_id', $googleId)
+            ->find_one();
+
+        if ($row !== false) {
+            return $this->userRepository->get(intval($row->id));
+        }
+
+        $email = strval($payload['email'] ?? '');
+
+        $login = $this->buildUniqueLogin($email, $googleId);
+
+        $name = strval($payload['name'] ?? '');
+
+        return $this->userRepository->store([
+            'login' => $login,
+            'password' => password_hash(bin2hex(random_bytes(12)), PASSWORD_DEFAULT),
+            'name' => strlen($name) > 0 ? $name : null,
+            'email' => strlen($email) > 0 ? $email : null,
+            'age' => 0,
+            'google_id' => $googleId,
+        ]);
+    }
+
+    private function buildUniqueLogin(string $email, string $googleId): string
+    {
+        $candidate = mb_strtolower($email);
+
+        if (strlen($candidate) > 0) {
+            $candidate = explode('@', $candidate)[0];
+        }
+
+        $candidate = preg_replace('/[^a-z0-9_]/', '', $candidate);
+
+        if (!$candidate || strlen($candidate) < 3) {
+            $candidate = 'google_' . substr($googleId, 0, 8);
+        }
+
+        $candidate = substr($candidate, 0, 20);
+
+        $login = $candidate;
+        $index = 1;
+
+        while ($this->userRepository->getByLogin($login) !== null) {
+            $suffix = strval($index);
+            $baseLen = max(1, 20 - strlen($suffix));
+
+            $login = substr($candidate, 0, $baseLen) . $suffix;
+            $index++;
+        }
+
+        return $login;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function verifyIdToken(string $idToken): array
+    {
+        if (strlen($idToken) === 0) {
+            throw new Exception('Google id_token is required.');
+        }
+
+        $response = $this->httpClient->request(
+            'GET',
+            'https://oauth2.googleapis.com/tokeninfo',
+            [
+                'query' => [
+                    'id_token' => $idToken,
+                ],
+                'http_errors' => false,
+                'timeout' => 5,
+            ]
+        );
+
+        if ($response->getStatusCode() !== 200) {
+            throw new Exception('Google token verification failed.');
+        }
+
+        $payload = json_decode(strval($response->getBody()), true);
+
+        if (!is_array($payload)) {
+            throw new Exception('Google token verification failed.');
+        }
+
+        $aud = strval($payload['aud'] ?? '');
+
+        if (!$this->isAllowedAudience($aud)) {
+            throw new Exception('Google token audience is not allowed.');
+        }
+
+        $emailVerified = strval($payload['email_verified'] ?? 'false');
+
+        if ($emailVerified !== 'true') {
+            throw new Exception('Google account e-mail is not verified.');
+        }
+
+        return $payload;
+    }
+
+    private function isAllowedAudience(string $aud): bool
+    {
+        if (strlen($aud) === 0) {
+            return false;
+        }
+
+        $clientIds = $this->settingsProvider->get('google_auth.client_ids') ?? '';
+
+        if (is_array($clientIds)) {
+            $allowed = $clientIds;
+        } else {
+            $allowed = array_filter(
+                array_map('trim', explode(',', strval($clientIds))),
+                fn (string $id) => strlen($id) > 0
+            );
+        }
+
+        if (count($allowed) === 0) {
+            return false;
+        }
+
+        return in_array($aud, $allowed);
+    }
+}

--- a/src/Services/GoogleAuthService.php
+++ b/src/Services/GoogleAuthService.php
@@ -13,7 +13,6 @@ use Plasticode\Settings\Interfaces\SettingsProviderInterface;
 class GoogleAuthService
 {
     private const TOKEN_LENGTH = 16;
-    private const DEFAULT_COOKIE_KEY = 'auth_token';
 
     private Client $httpClient;
     private SettingsProviderInterface $settingsProvider;
@@ -23,15 +22,13 @@ class GoogleAuthService
         Client $httpClient,
         SettingsProviderInterface $settingsProvider,
         UserRepositoryInterface $userRepository
-    ) {
+    )
+    {
         $this->httpClient = $httpClient;
         $this->settingsProvider = $settingsProvider;
         $this->userRepository = $userRepository;
     }
 
-    /**
-     * @return array{token:string,user:User,expires_at:string,cookie_key:string}
-     */
     public function signIn(string $idToken): array
     {
         $payload = $this->verifyIdToken($idToken);
@@ -50,8 +47,7 @@ class GoogleAuthService
             ])
             ->save();
 
-        $cookieKey = $this->settingsProvider->get('auth_token_key')
-            ?: self::DEFAULT_COOKIE_KEY;
+        $cookieKey = $this->settingsProvider->get('auth_token_key');
 
         return [
             'token' => $token,

--- a/src/routes.php
+++ b/src/routes.php
@@ -7,6 +7,7 @@ use App\Controllers\AssociationRecountController;
 use App\Controllers\ChunkController;
 use App\Controllers\FeedbackController;
 use App\Controllers\GameController;
+use App\Controllers\GoogleAuthController;
 use App\Controllers\IndexController;
 use App\Controllers\JobController;
 use App\Controllers\LanguageController;
@@ -62,6 +63,11 @@ $app->group(
                     '/captcha',
                     CaptchaController::class
                 );
+                $this->post(
+                    '/auth/google',
+                    GoogleAuthController::class . ':signIn'
+                )->setName('api.auth.google');
+
 
                 $this->get(
                     '/search/{query}',
@@ -378,6 +384,11 @@ $app->group(
                     '/signin',
                     AuthController::class . ':signIn'
                 )->setName('auth.signin');
+
+                $this->post(
+                    '/google',
+                    GoogleAuthController::class . ':signIn'
+                )->setName('auth.google');
             }
         );
 

--- a/views/main/local_layout.twig
+++ b/views/main/local_layout.twig
@@ -98,5 +98,30 @@
 {% block more_js %}
     <script src="{{ folders.local }}js/main.js"></script>
 
+    {% if google_auth_client_id %}
+        <script src="https://accounts.google.com/gsi/client" async defer></script>
+        <script>
+            window.onGoogleAuth = (response) => {
+                if (!response || !response.credential) {
+                    return;
+                }
+
+                $.post('{{ path_for('auth.google') }}', {
+                    credential: response.credential,
+                }).done(() => {
+                    reloadWindow();
+                }).fail((xhr) => {
+                    let error = 'Google auth failed.';
+
+                    if (xhr.responseJSON && xhr.responseJSON.message) {
+                        error = xhr.responseJSON.message;
+                    }
+
+                    alert(error);
+                });
+            };
+        </script>
+    {% endif %}
+
     {{ even_more_js }}
 {% endblock %}

--- a/views/modals/auth/signup.twig
+++ b/views/modals/auth/signup.twig
@@ -34,5 +34,25 @@
     <div class="checkbox">
         <label><input type="checkbox" name="su_remember" id="su_remember" checked>Запомнить</label>
     </div>
+
+    {% if google_auth_client_id %}
+        <hr />
+        <div class="text-center mb-1">или</div>
+        <div class="text-center">
+            <div id="g_id_onload"
+                data-client_id="{{ google_auth_client_id }}"
+                data-context="signup"
+                data-callback="onGoogleAuth"
+                data-auto_prompt="false"></div>
+            <div class="g_id_signin"
+                data-type="standard"
+                data-shape="rectangular"
+                data-theme="outline"
+                data-text="signup_with"
+                data-size="large"
+                data-logo_alignment="left"></div>
+        </div>
+    {% endif %}
+
     <span class="help-block">Уже зарегистрированы? <a href="javascript:void(0);" ng-click="switchFromTo('{{ modal_name }}', 'signIn')">Войдите</a>.</span>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Allow users to sign in with Google on the website and enable mobile apps / API clients to authenticate and receive a usable app auth token. 
- Persist Google identity links so existing and new Google users can be mapped to application users and reuse API auth flow. 

### Description
- Added `App\Services\GoogleAuthService` which verifies Google ID tokens via `https://oauth2.googleapis.com/tokeninfo`, enforces a configured audience allow-list (`google_auth.client_ids`), checks `email_verified`, provisions or finds a `users.google_id` linked user, and issues an app token in `auth_tokens` for API authentication. 
- Added `App\Controllers\GoogleAuthController` with `signIn` to accept ID tokens (body `id_token` or `credential`), set site auth cookie and return JSON `{ token, expires_at, user }`. 
- Registered new routes `POST /auth/google` (site) and `POST /api/v1/auth/google` (API/mobile) in `src/routes.php` and added a DB migration `db/migrations/20260410110000_add_google_id_to_users.php` to add a unique nullable `users.google_id`. 
- Updated `src/Models/User.php` to expose `is_google` and include it in serialized user payloads, added `google_id` to admin/entity settings in `settings/entities.yml`, added `google_auth` config in `settings/general.yml`, and exposed `google_auth_client_id` to Twig via `settings/view_globals.yml`. 
- Integrated front-end Google Sign-In: added Sign-In button to `views/modals/auth/signup.twig` and client callback script to `views/main/local_layout.twig` which posts the credential to the new endpoint and reloads on success. 

### Testing
- Ran PHP syntax checks (`php -l`) for `src/Services/GoogleAuthService.php`, `src/Controllers/GoogleAuthController.php`, modified `src/routes.php`, and `src/Models/User.php`, and they all passed. 
- Attempted `composer install`, but dependency installation failed in this environment due to the lockfile targeting older PHP versions (environment is PHP 8.5-dev), so dependency-based or integration tests could not be executed. 
- No automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88cd7d1e4832e8d11a536fbe4f120)